### PR TITLE
Remove license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Don't forget to polyfill require if you want to use it in Node.js. See the webpa
 
 <h2 align="center">LICENSE</h2>
 
-#### [MIT](./LICENSE)
+MIT
 
 [npm]: https://img.shields.io/npm/v/json-loader.svg
 [npm-url]: https://npmjs.com/package/json-loader


### PR DESCRIPTION
To allow inclusion in https://webpack.js.org/ docs.

See https://github.com/webpack/webpack.js.org/pull/804