### PR TITLE
fix: support `Infinity` & `NaN`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
   MIT License http://www.opensource.org/licenses/mit-license.php
   Author Tobias Koppers @sokra
 */
+
+import util from 'util';
 import JSON5 from 'json5';
 
 function Json5Loader(source) {
@@ -13,7 +15,7 @@ function Json5Loader(source) {
     throw new Error('Error parsing JSON5', (e));
   }
 
-  return `module.exports = ${JSON.stringify(value, null, '\t')}`;
+  return `module.exports = ${util.inspect(value, { depth: null })}`;
 }
 
 export default Json5Loader;

--- a/test/json5-loader.test.js
+++ b/test/json5-loader.test.js
@@ -28,4 +28,10 @@ describe(PROJECT_NAME, () => {
     expect(content).toBe('module.exports = { to: Infinity }');
     done();
   });
+
+  test('should preserve NaN', (done) => {
+    const content = Json5Loader.call({}, '{nan : NaN}');
+    expect(content).toBe('module.exports = { nan: NaN }');
+    done();
+  });
 });

--- a/test/json5-loader.test.js
+++ b/test/json5-loader.test.js
@@ -11,7 +11,7 @@ describe(PROJECT_NAME, () => {
 
   test('should convert to requires', (done) => {
     const content = Json5Loader.call({}, staticJson5);
-    expect(content).toBe('module.exports = {\n\t"name": "test"\n}');
+    expect(content).toBe('module.exports = { name: \'test\' }');
     done();
   });
 

--- a/test/json5-loader.test.js
+++ b/test/json5-loader.test.js
@@ -22,4 +22,10 @@ describe(PROJECT_NAME, () => {
     }).toThrow('Error parsing JSON5');
     done();
   });
+
+  test('should preserve Infinity', (done) => {
+    const content = Json5Loader.call({}, '{to : Infinity}');
+    expect(content).toBe('module.exports = { to: Infinity }');
+    done();
+  });
 });


### PR DESCRIPTION
Why?
 - If the JSON5 file contains Infinity or NaN they will be converted to null by JSON5.stringify, making the required JSON5 file unusable.

How?
 - Use util.inspect instead of JSON5.stringify, preserving types not allowed in native JSON such as Infinity and NaN.
